### PR TITLE
Use an options hash

### DIFF
--- a/lib/file/java/temp.rb
+++ b/lib/file/java/temp.rb
@@ -31,7 +31,7 @@ class File::Temp < File
   #    fh.puts 'hello world'
   #    fh.close
   #
-  def initialize(delete: true, template: 'rb_file_temp_XXXXXX', directory: TMPDIR)
+  def initialize(delete: true, template: 'rb_file_temp_XXXXXX', directory: TMPDIR, options: {})
     raise TypeError unless template.is_a?(String)
 
     # Since Java uses a GUID extension to generate a unique file name
@@ -47,9 +47,10 @@ class File::Temp < File
     end
 
     @file.deleteOnExit if delete
+    options[:mode] ||= 'wb+'
 
     path = @file.getName
-    super(path, 'wb+')
+    super(path, options)
 
     @path = path unless delete
   end

--- a/lib/file/unix/temp.rb
+++ b/lib/file/unix/temp.rb
@@ -51,7 +51,7 @@ class File::Temp < File
   #    fh.puts 'hello world'
   #    fh.close
   #
-  def initialize(delete: true, template: 'rb_file_temp_XXXXXX', directory: TMPDIR)
+  def initialize(delete: true, template: 'rb_file_temp_XXXXXX', directory: TMPDIR, options: {})
     @fptr = nil
 
     if delete
@@ -74,10 +74,12 @@ class File::Temp < File
       end
     end
 
+    options[:mode] ||= 'wb+'
+
     if delete
-      super(fd, 'wb+')
+      super(fd, options)
     else
-      super(@path, 'wb+')
+      super(@path, options)
     end
   end
 

--- a/lib/file/windows/temp.rb
+++ b/lib/file/windows/temp.rb
@@ -81,7 +81,7 @@ class File::Temp < File
   #    fh.puts 'hello world'
   #    fh.close
   #
-  def initialize(delete: true, template: 'rb_file_temp_XXXXXX', directory: TMPDIR)
+  def initialize(delete: true, template: 'rb_file_temp_XXXXXX', directory: TMPDIR, options: {})
     @fptr = nil
 
     if delete
@@ -102,10 +102,12 @@ class File::Temp < File
       end
     end
 
+    options[:mode] ||= 'wb+'
+
     if delete
-      super(fd, 'wb+')
+      super(fd, options)
     else
-      super(@path, 'wb+')
+      super(@path, options)
     end
   end
 


### PR DESCRIPTION
Allow an `options` hash to pass along to file creation. Use that instead of a plain mode string.