### PR TITLE
Update options kwargs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/lib/file/unix/temp.rb
+++ b/lib/file/unix/temp.rb
@@ -51,7 +51,7 @@ class File::Temp < File
   #    fh.puts 'hello world'
   #    fh.close
   #
-  def initialize(delete: true, template: 'rb_file_temp_XXXXXX', directory: TMPDIR, options: {})
+  def initialize(delete: true, template: 'rb_file_temp_XXXXXX', directory: TMPDIR, **options)
     @fptr = nil
 
     if delete
@@ -77,9 +77,9 @@ class File::Temp < File
     options[:mode] ||= 'wb+'
 
     if delete
-      super(fd, options)
+      super(fd, **options)
     else
-      super(@path, options)
+      super(@path, **options)
     end
   end
 

--- a/lib/file/windows/temp.rb
+++ b/lib/file/windows/temp.rb
@@ -81,7 +81,7 @@ class File::Temp < File
   #    fh.puts 'hello world'
   #    fh.close
   #
-  def initialize(delete: true, template: 'rb_file_temp_XXXXXX', directory: TMPDIR, options: {})
+  def initialize(delete: true, template: 'rb_file_temp_XXXXXX', directory: TMPDIR, **options)
     @fptr = nil
 
     if delete
@@ -105,9 +105,9 @@ class File::Temp < File
     options[:mode] ||= 'wb+'
 
     if delete
-      super(fd, options)
+      super(fd, **options)
     else
-      super(@path, options)
+      super(@path, **options)
     end
   end
 

--- a/spec/file_temp_spec.rb
+++ b/spec/file_temp_spec.rb
@@ -69,15 +69,15 @@ RSpec.describe File::Temp do
       expect(Dir["#{@dir}/temp_foo*"].length).to be >= 1
     end
 
-    example "constructor accepts a maximum of three arguments" do
+    example "other arguments are treated as file option arguments" do
       expect{
         @fh = File::Temp.new(
-          :delete     => true,
-          :template   => 'temp_bar_XXXXX',
-          :directory  => Dir.pwd,
-          :bogus      => 1
+          :delete    => true,
+          :template  => 'temp_bar_XXXXX',
+          :directory => Dir.pwd,
+          :mode      => 'xb'
         )
-      }.to raise_error(ArgumentError)
+      }.to raise_error(ArgumentError, /invalid access mode/)
     end
   end
 


### PR DESCRIPTION
Because of semantic changes in Ruby 3.x, it will no longer automatically treat a final hash as kwargs, so we have to update the options handler so that it works with both Ruby 2.x and Ruby 3.x.