### PR TITLE
Add 3.0, JRuby and Truffleruby to the workflow matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,9 +17,17 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
-        ruby-version: ['2.6', '2.7']
+        ruby-version: ['2.6', '2.7', '3.0', 'jruby', 'truffleruby']
         platform: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:
+          - ruby-version: truffleruby
+            platform: windows-latest
+          - ruby-version: jruby
+            platform: windows-latest
+          - ruby-version: 3.0
+            platform: windows-latest
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v2

--- a/spec/file_temp_spec.rb
+++ b/spec/file_temp_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe File::Temp do
           :directory => Dir.pwd,
           :mode      => 'xb'
         )
-      }.to raise_error(ArgumentError, /invalid access mode/)
+      }.to raise_error(ArgumentError, /invalid.*?(access)?.*?mode/) # Truffleruby missing the word 'access'
     end
   end
 


### PR DESCRIPTION
Skip JRuby and Truffleruby on Windows.