### PR TITLE
Use mkstemp instead of mktemp

### DIFF
--- a/lib/file/java/temp.rb
+++ b/lib/file/java/temp.rb
@@ -51,7 +51,7 @@ class File::Temp < File
     @file.deleteOnExit if delete
     options[:mode] ||= 'wb+'
 
-    path = @file.getName
+    path = @file.getAbsolutePath
     super(path, **options)
 
     @path = path unless delete

--- a/lib/file/unix/temp.rb
+++ b/lib/file/unix/temp.rb
@@ -31,7 +31,11 @@ class File::Temp < File
 
   # The name of the temporary file. Set to nil if the +delete+ option to the
   # constructor is true.
-  attr_reader :path
+  attr_writer :path
+
+  def path
+    @path || super
+  end
 
   # Creates a new, anonymous, temporary file in your tmpdir, or whichever
   # directory you specifiy.
@@ -56,6 +60,7 @@ class File::Temp < File
   #
   def initialize(delete: true, template: 'rb_file_temp_XXXXXX', directory: TMPDIR, **options)
     @fptr = nil
+    temp_path = nil
 
     if delete
       @fptr = tmpfile()
@@ -80,7 +85,7 @@ class File::Temp < File
           raise SystemCallError.new('mkstemp', FFI.errno)
         end
 
-        @path = ptr.read_string
+        temp_path = ptr.read_string
       ensure
         File.umask(omask)
       end
@@ -89,6 +94,8 @@ class File::Temp < File
     options[:mode] ||= 'wb+'
 
     super(fd, **options)
+
+    @path = temp_path
   end
 
   # The close method was overridden to ensure the internal file pointer that we

--- a/lib/file/unix/temp.rb
+++ b/lib/file/unix/temp.rb
@@ -62,6 +62,14 @@ class File::Temp < File
       raise SystemCallError.new('tmpfile', FFI.errno) if @fptr.null?
       fd = _fileno(@fptr)
     else
+      unless template.is_a?(String)
+        raise TypeError, "template must be a String"
+      end
+
+      unless template.end_with?('XXXXXX')
+        raise ArgumentError, "template must end with 6 'X' characters"
+      end
+
       begin
         omask = File.umask(077)
         full_template = File.join(directory, template)

--- a/lib/file/unix/temp.rb
+++ b/lib/file/unix/temp.rb
@@ -31,11 +31,7 @@ class File::Temp < File
 
   # The name of the temporary file. Set to nil if the +delete+ option to the
   # constructor is true.
-  attr_writer :path
-
-  def path
-    @path || super
-  end
+  attr_reader :path
 
   # Creates a new, anonymous, temporary file in your tmpdir, or whichever
   # directory you specifiy.

--- a/lib/file/windows/temp.rb
+++ b/lib/file/windows/temp.rb
@@ -92,6 +92,14 @@ class File::Temp < File
       @fptr = tmpfile()
       fd = _fileno(@fptr)
     else
+      unless template.is_a?(String)
+        raise TypeError, "template must be a String"
+      end
+
+      unless template.end_with?('XXXXXX')
+        raise ArgumentError, "template must end with 6 'X' characters"
+      end
+
       begin
         omask = File.umask(077)
         ptr = FFI::MemoryPointer.from_string(template)

--- a/spec/file_temp_spec.rb
+++ b/spec/file_temp_spec.rb
@@ -105,8 +105,7 @@ RSpec.describe File::Temp do
     end
 
     example 'an error is raised if a custom template is invalid' do
-      skip 'skipped on this platform' if osx || bsd
-      expect{ described_class.new(:delete => false, :template => 'xx') }.to raise_error(Errno::EINVAL)
+      expect{ described_class.new(:delete => false, :template => 'xx') }.to raise_error(ArgumentError, /template must end with 6/)
     end
   end
 


### PR DESCRIPTION
Replace mktemp with mkstemp on Unix. Thought I already did this?

Replace tmpnam with SecureRandom.